### PR TITLE
fix: remove duplicate output_fp.close() causing ValueError

### DIFF
--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -263,7 +263,6 @@ def run_evaluation(
             results_queue.close()
             results_queue.join_thread()
 
-    output_fp.close()
     logger.info('\nEvaluation finished.\n')
 def _process_instance_wrapper_mp(args):
     """Wrapper for multiprocessing, especially for imap_unordered."""


### PR DESCRIPTION
## Problem

In `evaluation/utils.py`, the file handle `output_fp` is opened at line 153 and properly closed in the `finally` block. However, there's a second `output_fp.close()` call immediately after the `try/finally` block (line 266).

Since the `finally` block always executes, the second `close()` call operates on an already-closed file, raising:
```
ValueError: I/O operation on closed file.
```

## Fix

Remove the redundant `output_fp.close()` call outside the `try/finally` block. The `finally` block already guarantees cleanup.

## Testing

Verified the control flow: `finally` runs in all cases (normal completion, `KeyboardInterrupt`, any exception), so the second `close()` is unreachable without the file already being closed.