### PR TITLE
style: use 'is None' instead of '== None' per PEP 8

### DIFF
--- a/autoagent/tools/meta/edit_workflow.py
+++ b/autoagent/tools/meta/edit_workflow.py
@@ -128,7 +128,7 @@ def single_event_to_code(event: dict, agent_info_dict: dict) -> str:
     - listen (list[str]): the listen to the event
     - agent (dict): the agent to run
     """
-    if event["listen"] == None or len(event["listen"]) == 0:
+    if event["listen"] is None or len(event["listen"]) == 0:
         event_method = "make_event"
     else: 
         event_method = "listen_group([{}])".format(", ".join(event["listen"]))

--- a/constant.py
+++ b/constant.py
@@ -11,7 +11,7 @@ def str_to_bool(value):
     if isinstance(value, bool):
         return value
         
-    if value == None:
+    if value is None:
         return None
         
     value = str(value).lower().strip()

--- a/evaluation/math500/run_infer.py
+++ b/evaluation/math500/run_infer.py
@@ -33,7 +33,7 @@ async def run_inference(item, save_dir, workflow):
 
     if workflow == "majority_voting":
         answer = await majority_voting(prompt)
-    elif workflow == None:
+    elif workflow is None:
         agent = get_math_solver_agent(model="deepseek/deepseek-chat")
         client = MetaChain()
         messages = [
@@ -93,7 +93,7 @@ async def main(args):
 
     print(f"Total number of items to process: {len(test_dataset)}")
 
-    if args.workflow == None:
+    if args.workflow is None:
         save_dir = os.path.join(args.save_dir, "math_solver")
         save_dir = Path(save_dir)
         save_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Replace `== None` with `is None` across 3 files, following [PEP 8 guidance](https://peps.python.org/pep-0008/#programming-recommendations):

> Comparisons to singletons like None should always be done with `is` or `is not`, never the equality operators.

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `autoagent/tools/meta/edit_workflow.py` | 131 | `== None` | `is None` |
| `constant.py` | 14 | `== None` | `is None` |
| `evaluation/math500/run_infer.py` | 36, 96 | `== None` | `is None` |

## Why

Using `==` for None checks can produce incorrect results if an object overrides `__eq__`. `is None` is both safer and idiomatic Python.