### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/autoagent/environment/browser_env.py
+++ b/autoagent/environment/browser_env.py
@@ -256,7 +256,7 @@ def _click_id(bid: str, button: Literal["left", "middle", "right"] = "left"):
                     # 等待页面完全加载
                     # 增加等待时间，确保页面完全加载
                     page.wait_for_load_state("networkidle", timeout=3000)
-            except:
+            except Exception:
                 pass
             
         return
@@ -322,7 +322,7 @@ def _checkMeetChallenge():
                       (!document.body.textContent.includes("请完成以下操作，验证您是真人。") &&
                        !document.body.textContent.includes("Verify you are human by completing the action below."))
             """, timeout=20000)
-        except:
+        except Exception:
             print("等待验证超时")
         
         # 检查是否仍在验证页面

--- a/autoagent/environment/local_env.py
+++ b/autoagent/environment/local_env.py
@@ -66,7 +66,7 @@ class LocalEnv:
                 conda_sh = Path(base_path) / "etc" / "profile.d" / "conda.sh"
                 if conda_sh.exists():
                     return str(conda_sh)
-        except:
+        except (subprocess.SubprocessError, OSError):
             pass
 
         # 3. If all fails, return None and handle in run_command

--- a/autoagent/registry.py
+++ b/autoagent/registry.py
@@ -97,7 +97,7 @@ class Registry:
                 wrapped_func = func
             try:
                 file_path = os.path.abspath(inspect.getfile(func))
-            except:
+            except (TypeError, OSError):
                 file_path = "Unknown"
             
             # 获取函数信息


### PR DESCRIPTION
## Problem

Several files use bare `except:` which catches `BaseException` including `SystemExit` and `KeyboardInterrupt`. This can mask critical errors and make debugging harder (PEP 8 E722).

## Changes

| File | Exception Type | Rationale |
|------|---------------|-----------|
| `browser_env.py` (2 sites) | `Exception` | Playwright timeout/navigation errors |
| `local_env.py` | `(subprocess.SubprocessError, OSError)` | Conda path discovery failures |
| `registry.py` | `(TypeError, OSError)` | `inspect.getfile()` on builtins/C extensions |

## Why specific types matter

Bare `except:` silently swallows `KeyboardInterrupt` (Ctrl+C) and `SystemExit`, preventing clean shutdown. Using specific exception types preserves the intended error-swallowing behavior while allowing critical signals to propagate.