### PR TITLE
Fix TypeError in tool calls and KeyError in orchestrator agent creation

### DIFF
--- a/autoagent/core.py
+++ b/autoagent/core.py
@@ -254,7 +254,17 @@ class MetaChain:
                 )
                 continue
             args = json.loads(tool_call.function.arguments)
-            
+            if not isinstance(args, dict):
+                # The LLM occasionally returns a bare JSON value (string, number)
+                # instead of a JSON object.  Map it to the first non-context
+                # parameter so the call can still proceed.
+                func_sig = inspect.signature(function_map[name])
+                first_param = next(
+                    (p for p in func_sig.parameters if p != __CTX_VARS_NAME__),
+                    None,
+                )
+                args = {first_param: args} if first_param else {}
+
             # debug_print(
             #     debug, f"Processing tool call: {name} with arguments {args}")
             func = function_map[name]

--- a/autoagent/tools/meta/edit_agents.py
+++ b/autoagent/tools/meta/edit_agents.py
@@ -257,6 +257,9 @@ def create_orchestrator_agent(agent_name: str, agent_description: str, sub_agent
     if agent_list.startswith("[ERROR]"):
         return "Failed to list agents. Error: " + agent_list
     agent_dict = json.loads(agent_list)
+    missing = [sa["name"] for sa in sub_agents if sa["name"] not in agent_dict]
+    if missing:
+        return f"[ERROR] Sub-agent(s) not found in registry: {missing}. Register them first."
     sub_agent_info = [agent_dict[sub_agent["name"]] for sub_agent in sub_agents]
     import_agent_str = ""
     for ainfo in sub_agent_info:


### PR DESCRIPTION
Fixes #73 and #71.

**Issue #73** — `TypeError: 'str' object does not support item assignment`

`json.loads(tool_call.function.arguments)` can return a string when the LLM outputs a bare JSON value instead of a JSON object. The fix checks the type after parsing and maps the value to the first non-context parameter.

**Issue #71** — `KeyError: 'Market Analysis Agent'`

`create_orchestrator_agent` blindly looked up sub-agent names in `agent_dict` without checking they exist first. The fix returns a descriptive error message listing which sub-agents are missing from the registry.