### PR TITLE
Fix python_requires placement in setup.cfg and add regression test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ package_dir =
 packages = find_namespace:
 zip_safe = True
 include_package_data = True
+python_requires = >=3.10
 install_requires =
     numpy
     openai>=1.52.0
@@ -67,8 +68,6 @@ install_requires =
 [options.packages.find]
 where = .
 include = autoagent*
-    
-python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -1,0 +1,24 @@
+import configparser
+from pathlib import Path
+import unittest
+
+
+class SetupCfgTests(unittest.TestCase):
+    def test_python_requires_is_defined_under_options(self):
+        setup_cfg = Path(__file__).resolve().parents[1] / "setup.cfg"
+        parser = configparser.ConfigParser()
+        parser.read(setup_cfg, encoding="utf-8")
+
+        self.assertTrue(parser.has_option("options", "python_requires"))
+        self.assertEqual(parser.get("options", "python_requires"), ">=3.10")
+
+    def test_python_requires_is_not_under_packages_find(self):
+        setup_cfg = Path(__file__).resolve().parents[1] / "setup.cfg"
+        parser = configparser.ConfigParser()
+        parser.read(setup_cfg, encoding="utf-8")
+
+        self.assertFalse(parser.has_option("options.packages.find", "python_requires"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\nFix packaging metadata so Python version constraints are enforced correctly, and add a regression test to prevent future misplacement.\n\n## Problem\n was set under  instead of . This placement can be ignored by packaging tools, allowing installation on unsupported Python versions.\n\n## Changes\n- Move  to  in .\n- Add  verifying: (1)  exists under , (2) not under .\n\n## Validation\n- \n- Listing 'autoagent'...
Listing 'autoagent/agents'...
Listing 'autoagent/agents/math'...
Listing 'autoagent/agents/meta_agent'...
Listing 'autoagent/agents/system_agent'...
Listing 'autoagent/cli_utils'...
Listing 'autoagent/environment'...
Listing 'autoagent/environment/cookie_json'...
Listing 'autoagent/environment/markdown_browser'...
Listing 'autoagent/flow'...
Listing 'autoagent/memory'...
Listing 'autoagent/memory/code_tree'...
Listing 'autoagent/repl'...
Listing 'autoagent/tools'...
Listing 'autoagent/tools/meta'...
Listing 'autoagent/workflows'...\n