### PR TITLE
[security] fix(api): require token for tool server

### DIFF
--- a/autoagent/server.py
+++ b/autoagent/server.py
@@ -1,12 +1,32 @@
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+import os
 from contextlib import asynccontextmanager
-from typing import Dict, Any, Optional, List
-from autoagent.registry import registry
+from typing import Any, Dict, List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from pydantic import BaseModel
+
 from autoagent import MetaChain
+from autoagent.registry import registry
 from autoagent.types import Agent, Response
-import importlib
 import inspect
+
+
+def api_token() -> str:
+    token = os.environ.get("AUTOAGENT_API_TOKEN", "").strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AUTOAGENT_API_TOKEN must be set before using the API server",
+        )
+    return token
+
+
+async def require_api_token(request: Request, token: str = Depends(api_token)) -> None:
+    auth = request.headers.get("authorization", "").strip()
+    prefix = "Bearer "
+    if not auth.startswith(prefix) or auth[len(prefix) :].strip() != token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="valid bearer token required")
+
 
 # 定义lifespan上下文管理器
 @asynccontextmanager
@@ -17,24 +37,36 @@ async def lifespan(app: FastAPI):
     # 关闭时执行
     # 清理代码（如果需要）
 
-app = FastAPI(title="MetaChain API", lifespan=lifespan)
+
+app = FastAPI(title="MetaChain API", lifespan=lifespan, dependencies=[Depends(require_api_token)])
+
 
 class ToolRequest(BaseModel):
     args: Dict[str, Any]
+
 
 class AgentRequest(BaseModel):
     model: str
     query: str
     context_variables: Optional[Dict[str, Any]] = {}
 
+
 class Message(BaseModel):
     role: str
     content: str
+
 
 class AgentResponse(BaseModel):
     result: str
     messages: List
     agent_name: str
+
+
+@app.get("/health", dependencies=[])
+async def health():
+    return {"status": "ok"}
+
+
 # 为所有注册的tools创建endpoints
 @app.on_event("startup")
 def create_tool_endpoints():
@@ -48,7 +80,7 @@ def create_tool_endpoints():
                     name for name, param in sig.parameters.items()
                     if param.default == inspect.Parameter.empty
                 }
-                
+
                 # 验证是否提供了所有必需参数
                 if not all(param in request.args for param in required_params):
                     missing = required_params - request.args.keys()
@@ -56,36 +88,38 @@ def create_tool_endpoints():
                         status_code=400,
                         detail=f"Missing required parameters: {missing}"
                     )
-                
+
                 result = func(**request.args)
                 return {"status": "success", "result": result}
             except Exception as e:
                 raise HTTPException(status_code=400, detail=str(e))
-        
+
         # 添加endpoint到FastAPI应用
         endpoint = create_tool_endpoint
         endpoint.__name__ = f"tool_{tool_name}"
         app.post(f"/tools/{tool_name}")(endpoint)
+
+
 # 重写agent endpoints创建逻辑
 @app.on_event("startup")
 def create_agent_endpoints():
     for agent_name, agent_func in registry.agents.items():
         async def create_agent_endpoint(
-            request: AgentRequest, 
+            request: AgentRequest,
             func=agent_func
         ) -> AgentResponse:
             try:
                 # 创建agent实例
                 agent = func(model=request.model)
-                
+
                 # 创建MetaChain实例
                 mc = MetaChain()
-                
+
                 # 构建messages
                 messages = [
                     {"role": "user", "content": request.query}
                 ]
-                
+
                 # 运行agent
                 response = mc.run(
                     agent=agent,
@@ -93,22 +127,23 @@ def create_agent_endpoints():
                     context_storage=request.context_variables,
                     debug=True
                 )
-                
+
                 return AgentResponse(
                     result=response.messages[-1]['content'],
                     messages=response.messages,
                     agent_name=agent.name
                 )
-                
+
             except Exception as e:
                 raise HTTPException(
                     status_code=400,
                     detail=f"Agent execution failed: {str(e)}"
                 )
-        
+
         endpoint = create_agent_endpoint
         endpoint.__name__ = f"agent_{agent_name}"
         app.post(f"/agents/{agent_name}/run")(endpoint)
+
 
 # 获取所有可用的agents信息
 @app.get("/agents")
@@ -122,6 +157,7 @@ async def list_agents():
         for name, info in registry.agents_info.items()
     }
 
+
 # 获取特定agent的详细信息
 @app.get("/agents/{agent_name}")
 async def get_agent_info(agent_name: str):
@@ -130,7 +166,7 @@ async def get_agent_info(agent_name: str):
             status_code=404,
             detail=f"Agent {agent_name} not found"
         )
-    
+
     info = registry.agents_info[agent_name]
     return {
         "name": agent_name,
@@ -139,6 +175,10 @@ async def get_agent_info(agent_name: str):
         "file_path": info.file_path
     }
 
+
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    host = os.environ.get("AUTOAGENT_API_HOST", "127.0.0.1")
+    port = int(os.environ.get("AUTOAGENT_API_PORT", "8000"))
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def load_server(monkeypatch):
+    calls = []
+
+    def fake_tool(command, context_variables=None):
+        calls.append((command, context_variables))
+        return {"status": 0, "result": command}
+
+    registry = types.SimpleNamespace(
+        tools={"execute_command": fake_tool},
+        agents={},
+        agents_info={},
+    )
+    mod_registry = types.ModuleType("autoagent.registry")
+    mod_registry.registry = registry
+    mod_autoagent = types.ModuleType("autoagent")
+    mod_autoagent.MetaChain = object
+    mod_types = types.ModuleType("autoagent.types")
+    mod_types.Agent = object
+    mod_types.Response = object
+    monkeypatch.setitem(sys.modules, "autoagent.registry", mod_registry)
+    monkeypatch.setitem(sys.modules, "autoagent", mod_autoagent)
+    monkeypatch.setitem(sys.modules, "autoagent.types", mod_types)
+
+    server_path = Path(__file__).resolve().parents[1] / "autoagent" / "server.py"
+    spec = importlib.util.spec_from_file_location("autoagent_server_under_test", server_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.create_tool_endpoints()
+    return module, calls
+
+
+def test_tool_endpoint_requires_api_token(monkeypatch):
+    monkeypatch.setenv("AUTOAGENT_API_TOKEN", "secret-token")
+    module, calls = load_server(monkeypatch)
+    client = TestClient(module.app)
+
+    response = client.post(
+        "/tools/execute_command",
+        json={"args": {"command": "id", "context_variables": {}}},
+    )
+
+    assert response.status_code == 401
+    assert calls == []
+
+
+def test_tool_endpoint_accepts_valid_bearer_token(monkeypatch):
+    monkeypatch.setenv("AUTOAGENT_API_TOKEN", "secret-token")
+    module, calls = load_server(monkeypatch)
+    client = TestClient(module.app)
+
+    response = client.post(
+        "/tools/execute_command",
+        headers={"authorization": "Bearer secret-token"},
+        json={"args": {"command": "id", "context_variables": {}}},
+    )
+
+    assert response.status_code == 200
+    assert calls == [("id", {})]
+
+
+def test_api_refuses_to_run_when_token_is_unconfigured(monkeypatch):
+    monkeypatch.delenv("AUTOAGENT_API_TOKEN", raising=False)
+    module, calls = load_server(monkeypatch)
+    client = TestClient(module.app)
+
+    response = client.post(
+        "/tools/execute_command",
+        json={"args": {"command": "id", "context_variables": {}}},
+    )
+
+    assert response.status_code == 503
+    assert calls == []


### PR DESCRIPTION
## Summary

This PR hardens the AutoAgent FastAPI server so registered tools and agents are not exposed as unauthenticated network-callable actions.

The patch adds a bearer-token requirement for the API server and changes the default bind host from `0.0.0.0` to `127.0.0.1`. Operators who intentionally expose the server can still configure the host/port explicitly, but tool and agent routes now require `AUTOAGENT_API_TOKEN` before any registered tool function is invoked.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated FastAPI tool API | Any network client that can reach the server could invoke registered tools such as `execute_command`, file write/read helpers, or agent runs | Critical |

## Before this PR

- `autoagent/server.py` dynamically registered every tool at `/tools/{tool_name}`.
- Tool routes had no authentication or authorization dependency.
- Agent routes at `/agents/{agent_name}/run` had no authentication or authorization dependency.
- The server started on `0.0.0.0:8000` when executed as `python -m autoagent.server` or equivalent.
- A reachable server could invoke dangerous tools, including shell execution helpers, directly from unauthenticated HTTP requests.

## After this PR

- API routes require `Authorization: Bearer <AUTOAGENT_API_TOKEN>`.
- If `AUTOAGENT_API_TOKEN` is unset, the API refuses tool/agent calls with a configuration error instead of running them unauthenticated.
- The default bind host is now `127.0.0.1`.
- Operators can still set `AUTOAGENT_API_HOST` and `AUTOAGENT_API_PORT` explicitly for their deployment.
- Regression tests cover missing token, valid token, and unconfigured-token behavior.

## Why this matters

AutoAgent's registered tool set includes powerful local actions. Exposing those tools through an unauthenticated HTTP server turns the API into a remote command and file-operation surface for anyone who can reach the port.

Because developer agents often run with API keys, repository checkouts, local credentials, and writable workspaces, a network-reachable unauthenticated tool server can lead to host command execution and credential disclosure.

## Attack flow

```text
Attacker reaches AutoAgent API server on port 8000
    -> sends POST /tools/execute_command with a shell command
        -> server dispatches directly to the registered tool
            -> tool executes in the AutoAgent environment
                -> attacker reads files, writes files, or exfiltrates secrets
```

## Affected code

| Area | Files |
|------|-------|
| API server auth boundary | `autoagent/server.py` |
| Regression coverage | `tests/test_server_auth.py` |

## Root cause

- Registered tools were exposed directly as HTTP endpoints.
- Route creation did not attach an authentication dependency.
- Server startup bound to all interfaces by default.
- Tool registration includes high-impact tools, so missing API auth becomes a command/file execution boundary issue rather than a metadata-only exposure.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unauthenticated FastAPI tool API | 9.8 Critical | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |

Rationale:

- Network attack vector when the server is reachable.
- No privileges or user interaction are required.
- Successful exploitation can execute registered tools with the privileges and credentials of the AutoAgent process.

## Safe reproduction steps

On vulnerable code:

1. Start the API server.
2. Send a request such as:

   ```bash
   curl -s http://127.0.0.1:8000/tools/execute_command \
     -H 'content-type: application/json' \
     -d '{"args":{"command":"id","context_variables":{}}}'
   ```

3. Observe that the server attempts to invoke the registered tool without requiring credentials.

With this PR:

1. Start the server without `AUTOAGENT_API_TOKEN`.
2. Tool and agent API calls return a configuration error instead of executing.
3. Set `AUTOAGENT_API_TOKEN` and include `Authorization: Bearer <token>` to call the API intentionally.

## Expected vulnerable behavior

A request to `/tools/execute_command` or another registered tool endpoint can reach the tool function without any authentication check.

## Changes in this PR

- Adds `AUTOAGENT_API_TOKEN` bearer-token enforcement.
- Adds a default-deny behavior when the token is not configured.
- Changes default Uvicorn host to `127.0.0.1`.
- Adds `AUTOAGENT_API_HOST` and `AUTOAGENT_API_PORT` environment overrides.
- Adds FastAPI route tests for API-token enforcement.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API hardening | `autoagent/server.py` | Added bearer-token dependency, default-deny token config, and loopback default host. |
| Tests | `tests/test_server_auth.py` | Added regression tests proving unauthenticated tool calls are denied and valid bearer tokens work. |

## Maintainer impact

- Deployments using the API server must configure `AUTOAGENT_API_TOKEN` and send it as a bearer token.
- Local-only development remains straightforward with `AUTOAGENT_API_HOST` defaulting to `127.0.0.1`.
- Intentional remote deployments can still opt into a remote bind with `AUTOAGENT_API_HOST=0.0.0.0`, but API calls remain authenticated.

## Fix rationale

Registered tools are privileged actions, not public metadata. A simple bearer token provides a narrow compatibility-preserving guard while keeping the current dynamic route model intact. Binding to loopback by default also avoids accidental LAN exposure for local development.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3 -m pytest tests/test_server_auth.py -q`
- [x] `python3 -m py_compile autoagent/server.py tests/test_server_auth.py`
- [x] `git diff --check`

## Disclosure notes

- This PR is bounded to the FastAPI server auth boundary.
- It does not change the semantics of individual tools once an authenticated caller invokes them.
- It does not address the separate Docker TCP command channel or File Surfer path containment issues, which are handled separately.
