### PR TITLE
[security] fix: authenticate TCP command server

### DIFF
--- a/autoagent/environment/docker_env.py
+++ b/autoagent/environment/docker_env.py
@@ -5,6 +5,7 @@ from constant import BASE_IMAGES, AI_USER, GITHUB_AI_TOKEN
 import time
 import socket
 import json
+import secrets
 from pathlib import Path
 import shutil
 wd = Path(__file__).parent.resolve()
@@ -38,6 +39,7 @@ class DockerEnv:
         self.git_clone = config.git_clone
         self.setup_package = config.setup_package
         self.communication_port = config.communication_port
+        self.command_token = secrets.token_hex(32)
         self.conda_path = config.conda_path
         
     def init_container(self):
@@ -100,7 +102,7 @@ class DockerEnv:
             "-v", f"{self.local_workplace}:{self.docker_workplace}",
             "-w", f"{self.docker_workplace}", "-p", f"{self.communication_port}:{self.communication_port}", BASE_IMAGES,
             "/bin/bash", "-c", 
-            f"python3 {self.docker_workplace}/tcp_server.py --workplace {self.workplace_name} --conda_path {self.conda_path} --port {self.communication_port}"
+            f"python3 {self.docker_workplace}/tcp_server.py --workplace {self.workplace_name} --conda_path {self.conda_path} --port {self.communication_port} --token {self.command_token}"
         ]
         # execute the docker command
         result = subprocess.run(docker_command, capture_output=True, text=True)
@@ -159,7 +161,8 @@ class DockerEnv:
         
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect((hostname, port))
-            s.sendall(command.encode())
+            payload = json.dumps({"token": self.command_token, "command": command})
+            s.sendall(payload.encode())
             
             partial_line = ""
             while True:

--- a/autoagent/environment/tcp_server.py
+++ b/autoagent/environment/tcp_server.py
@@ -2,41 +2,71 @@ import socket
 import subprocess
 import json
 import argparse
+import hmac
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--workplace", type=str, default=None)
 parser.add_argument("--conda_path", type=str, default=None)
 parser.add_argument("--port", type=int, default=None)
+parser.add_argument("--token", type=str, default=None)
 args = parser.parse_args()
+
+
+def receive_all(conn, buffer_size=4096):
+    data = b""
+    while True:
+        part = conn.recv(buffer_size)
+        data += part
+        if len(part) < buffer_size:
+            # 如果接收的数据小于缓冲区大小，可能已经接收完毕
+            break
+    return data.decode()
+
+
+def parse_command_request(raw_request: str, expected_token: str) -> str:
+    try:
+        request = json.loads(raw_request)
+    except json.JSONDecodeError as exc:
+        raise ValueError("command request must be JSON") from exc
+    if not isinstance(request, dict):
+        raise ValueError("command request must be a JSON object")
+    token = request.get("token")
+    command = request.get("command")
+    if not isinstance(token, str) or not hmac.compare_digest(token, expected_token):
+        raise PermissionError("valid command token required")
+    if not isinstance(command, str) or not command:
+        raise ValueError("command must be a non-empty string")
+    return command
+
 
 if __name__ == "__main__":
     assert args.workplace is not None, "Workplace is not specified"
     assert args.conda_path is not None, "Conda path is not specified"
     assert args.port is not None, "Port is not specified"
+    assert args.token is not None and args.token, "Command token is not specified"
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.bind(("0.0.0.0", args.port))
     server.listen(1)
 
     print(f"Listening on port {args.port}...")
-    def receive_all(conn, buffer_size=4096):
-        data = b""
-        while True:
-            part = conn.recv(buffer_size)
-            data += part
-            if len(part) < buffer_size:
-                # 如果接收的数据小于缓冲区大小，可能已经接收完毕
-                break
-        return data.decode()
-
     while True:
         conn, addr = server.accept()
         print(f"Connection from {addr}")
         while True:
-            # command = conn.recv(1024).decode()
-            command = receive_all(conn)
-            if not command:
+            raw_request = receive_all(conn)
+            if not raw_request:
                 break
-            
+            try:
+                command = parse_command_request(raw_request, args.token)
+            except Exception as e:
+                error_response = {
+                    "type": "final",
+                    "status": -1,
+                    "result": f"Rejected command request: {str(e)}"
+                }
+                conn.send(json.dumps(error_response).encode() + b"\n")
+                break
+
             # Execute the command
             try:
                 modified_command = f"/bin/bash -c 'source {args.conda_path}/etc/profile.d/conda.sh && conda activate autogpt && cd /{args.workplace} && {command}'"
@@ -69,12 +99,4 @@ if __name__ == "__main__":
                 }
                 conn.send(json.dumps(error_response).encode() + b"\n")
 
-            # Create a JSON response
-            # response = {
-            #     "status": exit_code,
-            #     "result": output
-            # }
-            
-            # # Send the JSON response
-            # conn.send(json.dumps(response).encode())
         conn.close()

--- a/autoagent/tcp_server.py
+++ b/autoagent/tcp_server.py
@@ -1,40 +1,59 @@
+import argparse
+import hmac
+import json
 import socket
 import subprocess
-import json
-import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--workplace", type=str, default=None)
+parser.add_argument("--token", type=str, default=None)
 args = parser.parse_args()
+
+
+def receive_all(conn, buffer_size=4096):
+    data = b""
+    while True:
+        part = conn.recv(buffer_size)
+        data += part
+        if len(part) < buffer_size:
+            # 如果接收的数据小于缓冲区大小，可能已经接收完毕
+            break
+    return data.decode()
+
+
+def parse_command_request(raw_request: str, expected_token: str) -> str:
+    try:
+        request = json.loads(raw_request)
+    except json.JSONDecodeError as exc:
+        raise ValueError("command request must be JSON") from exc
+    if not isinstance(request, dict):
+        raise ValueError("command request must be a JSON object")
+    token = request.get("token")
+    command = request.get("command")
+    if not isinstance(token, str) or not hmac.compare_digest(token, expected_token):
+        raise PermissionError("valid command token required")
+    if not isinstance(command, str) or not command:
+        raise ValueError("command must be a non-empty string")
+    return command
+
 
 if __name__ == "__main__":
     assert args.workplace is not None, "Workplace is not specified"
+    assert args.token is not None and args.token, "Command token is not specified"
     server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     server.bind(("0.0.0.0", 12345))
     server.listen(1)
 
     print("Listening on port 12345...")
-    def receive_all(conn, buffer_size=4096):
-        data = b""
-        while True:
-            part = conn.recv(buffer_size)
-            data += part
-            if len(part) < buffer_size:
-                # 如果接收的数据小于缓冲区大小，可能已经接收完毕
-                break
-        return data.decode()
-
     while True:
         conn, addr = server.accept()
         print(f"Connection from {addr}")
         while True:
-            # command = conn.recv(1024).decode()
-            command = receive_all(conn)
-            if not command:
+            raw_request = receive_all(conn)
+            if not raw_request:
                 break
-            
-            # Execute the command
             try:
+                command = parse_command_request(raw_request, args.token)
                 modified_command = f"/bin/bash -c 'source /home/user/micromamba/etc/profile.d/conda.sh && conda activate autogpt && cd /{args.workplace} && {command}'"
                 process = subprocess.Popen(modified_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
                 output = ''
@@ -48,14 +67,14 @@ if __name__ == "__main__":
                 exit_code = process.wait()
             except Exception as e:
                 exit_code = -1
-                output = f"Error running command: {str(e)}"
+                output = f"Rejected or failed command request: {str(e)}"
 
             # Create a JSON response
             response = {
                 "status": exit_code,
                 "result": output
             }
-            
+
             # Send the JSON response
             conn.send(json.dumps(response).encode())
         conn.close()

--- a/tests/test_tcp_server_auth.py
+++ b/tests/test_tcp_server_auth.py
@@ -1,0 +1,111 @@
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def _connect(port: int, timeout: float = 5):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            return socket.create_connection(("127.0.0.1", port), timeout=0.5)
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError("tcp server did not start")
+
+
+def _read_all(sock: socket.socket) -> str:
+    data = b""
+    while True:
+        chunk = sock.recv(65535)
+        if not chunk:
+            break
+        data += chunk
+    return data.decode(errors="replace")
+
+
+def test_environment_tcp_server_requires_command_token(tmp_path):
+    conda = tmp_path / "conda"
+    profile = conda / "etc" / "profile.d"
+    profile.mkdir(parents=True)
+    (profile / "conda.sh").write_text("conda(){ return 0; }\n")
+    workplace = tmp_path / "workplace"
+    workplace.mkdir()
+    marker = tmp_path / "unauthorized_marker"
+    port = 19191
+    server = Path(__file__).resolve().parents[1] / "autoagent" / "environment" / "tcp_server.py"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(server),
+            "--workplace",
+            str(workplace).lstrip("/"),
+            "--conda_path",
+            str(conda),
+            "--port",
+            str(port),
+            "--token",
+            "expected-token",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        sock = _connect(port)
+        sock.sendall(f"echo bad > {marker}".encode())
+        sock.shutdown(socket.SHUT_WR)
+        response = _read_all(sock)
+        assert "valid command token required" in response or "command request must be JSON" in response
+        assert not marker.exists()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_environment_tcp_server_accepts_valid_command_token(tmp_path):
+    conda = tmp_path / "conda"
+    profile = conda / "etc" / "profile.d"
+    profile.mkdir(parents=True)
+    (profile / "conda.sh").write_text("conda(){ return 0; }\n")
+    workplace = tmp_path / "workplace"
+    workplace.mkdir()
+    marker = tmp_path / "authorized_marker"
+    port = 19192
+    server = Path(__file__).resolve().parents[1] / "autoagent" / "environment" / "tcp_server.py"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(server),
+            "--workplace",
+            str(workplace).lstrip("/"),
+            "--conda_path",
+            str(conda),
+            "--port",
+            str(port),
+            "--token",
+            "expected-token",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        sock = _connect(port)
+        sock.sendall(json.dumps({"token": "expected-token", "command": f"echo ok > {marker}"}).encode())
+        sock.shutdown(socket.SHUT_WR)
+        response = _read_all(sock)
+        assert '"status": 0' in response
+        assert marker.read_text().strip() == "ok"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary

This PR hardens AutoAgent's TCP command channel so direct network clients cannot execute commands without a per-environment command token.

The Docker environment now generates a random command token when it is created, starts the container-side TCP server with that token, and sends commands as JSON containing both the token and command. The TCP servers reject non-JSON requests, missing tokens, invalid tokens, and empty commands before reaching the shell execution path.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unauthenticated TCP command server | Any client that could reach the published TCP port could send shell commands to the AutoAgent command server | Critical |

## Before this PR

- The container-side TCP server bound to `0.0.0.0`.
- `DockerEnv` published the TCP port with `docker run -p <port>:<port>`.
- The server accepted raw bytes as a command.
- The command was interpolated into a shell string and executed with `subprocess.Popen(..., shell=True)`.
- The Docker container was started as root and had a bind-mounted workspace.

## After this PR

- `DockerEnv` generates a random command token for each environment instance.
- The Docker startup command passes that token to the TCP server.
- `DockerEnv.run_command()` sends JSON containing `{ "token": ..., "command": ... }`.
- The TCP servers reject unauthenticated raw commands before shell execution.
- Regression tests cover rejected unauthenticated command attempts and accepted token-authenticated commands.

## Why this matters

The TCP command server is a high-privilege execution channel. In Docker mode it is reachable through a host-published port and runs commands inside a root container with a mounted workspace. Without authentication, any process or network peer that can connect to the port can execute shell commands and alter the workspace.

## Attack flow

```text
Attacker connects to the published AutoAgent TCP port
    -> sends raw shell command bytes
        -> TCP server treats the bytes as a trusted command
            -> command runs through /bin/bash -c in the container
                -> attacker reads or writes the mounted workspace
```

## Affected code

| Area | Files |
|------|-------|
| Docker command channel | `autoagent/environment/docker_env.py` |
| Container TCP server | `autoagent/environment/tcp_server.py` |
| Standalone TCP server | `autoagent/tcp_server.py` |
| Regression coverage | `tests/test_tcp_server_auth.py` |

## Root cause

- The TCP protocol did not authenticate command senders.
- The server accepted arbitrary raw bytes as commands.
- Docker published the port to the host while the server listened on all interfaces.
- The command channel directly reached a shell execution sink.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unauthenticated TCP command server | 9.8 Critical | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |

Rationale:

- The issue is network-reachable wherever the published port is reachable.
- No privileges or user interaction are required.
- Successful exploitation provides command execution in the AutoAgent command environment and access to the mounted workspace.

## Safe reproduction steps

On vulnerable code:

1. Start an AutoAgent Docker environment that launches `tcp_server.py`.
2. Connect to the published port.
3. Send raw command bytes such as:

   ```bash
   id; touch /workplace/tcp_pwned
   ```

4. Observe command output and the created file.

With this PR:

1. Start the TCP server with a token.
2. Send the same raw command bytes.
3. The server rejects the request and does not execute the command.
4. Commands sent by `DockerEnv.run_command()` still work because they include the generated token.

## Expected vulnerable behavior

A TCP client can send a shell command as raw bytes and the server executes it without checking who sent it.

## Changes in this PR

- Adds a command token argument to TCP server startup.
- Adds JSON request parsing for TCP command requests.
- Verifies tokens with constant-time comparison before command execution.
- Rejects malformed, unauthenticated, and empty command requests.
- Updates `DockerEnv.run_command()` to send authenticated JSON command requests.
- Adds regression tests for rejected and accepted TCP command requests.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| TCP hardening | `autoagent/environment/tcp_server.py`, `autoagent/tcp_server.py` | Require JSON command requests with a valid token before executing. |
| Docker client | `autoagent/environment/docker_env.py` | Generate a command token, pass it to the server, and include it in command requests. |
| Tests | `tests/test_tcp_server_auth.py` | Verify raw unauthenticated commands do not execute and valid token-authenticated commands still do. |

## Maintainer impact

- Existing `DockerEnv.run_command()` callers continue using the same Python API.
- Direct manual TCP clients must switch to the JSON protocol and include the environment token.
- The token is generated per `DockerEnv` instance and is not a user-facing long-term credential.

## Fix rationale

The TCP server is a command execution channel, so it must authenticate the coordinator that is allowed to send commands. A per-environment random token keeps the existing TCP architecture while preventing arbitrary network clients from sending commands directly.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3 -m pytest tests/test_tcp_server_auth.py -q`
- [x] `python3 -m py_compile autoagent/environment/tcp_server.py autoagent/tcp_server.py autoagent/environment/docker_env.py tests/test_tcp_server_auth.py`
- [x] `git diff --check`

## Disclosure notes

- This PR is bounded to the TCP command server authentication boundary.
- It does not address the separate FastAPI tool server exposure or File Surfer path containment issue, which are handled separately.
- It keeps the existing shell execution behavior for authenticated `DockerEnv.run_command()` calls.
