### PR TITLE
[security] fix: contain File Surfer workspace paths

### DIFF
--- a/autoagent/environment/markdown_browser/requests_markdown_browser.py
+++ b/autoagent/environment/markdown_browser/requests_markdown_browser.py
@@ -93,14 +93,27 @@ class RequestsMarkdownBrowser(AbstractMarkdownBrowser):
     def address(self) -> str:
         """Return the address of the current page."""
         return self.history[-1][0]
+    def _contained_path(self, root: str, candidate: str) -> str:
+        root_path = os.path.realpath(os.path.abspath(os.path.expanduser(root)))
+        candidate_path = os.path.realpath(os.path.abspath(os.path.expanduser(candidate)))
+        if os.path.commonpath([root_path, candidate_path]) != root_path:
+            raise ValueError(f"Path escapes the workspace: {candidate}")
+        return candidate_path
+
     def _convert_docker_to_local(self, path: str) -> str:
-        assert self.docker_workplace in path, f"The path must be a absolute path from `{self.docker_workplace}/` directory"
-        local_path = path.replace(self.docker_workplace, self.local_workplace)
-        return local_path
+        docker_root = pathlib.PurePosixPath(self.docker_workplace)
+        docker_path = pathlib.PurePosixPath(path)
+        try:
+            relative_path = docker_path.relative_to(docker_root)
+        except ValueError as exc:
+            raise ValueError(f"The path must be an absolute path under `{self.docker_workplace}/`") from exc
+        local_path = os.path.join(self.local_workplace, *relative_path.parts)
+        return self._contained_path(self.local_workplace, local_path)
+
     def _convert_local_to_docker(self, path: str) -> str:
-        assert self.local_workplace in path, f"The path must be a absolute path from `{self.local_workplace}/` directory"
-        docker_path = path.replace(self.local_workplace, self.docker_workplace)
-        return docker_path
+        local_path = self._contained_path(self.local_workplace, path)
+        relative_path = os.path.relpath(local_path, os.path.realpath(os.path.abspath(self.local_workplace)))
+        return pathlib.PurePosixPath(self.docker_workplace, *pathlib.PurePath(relative_path).parts).as_posix()
 
     def set_address(self, uri_or_path: str) -> None:
         """Sets the address of the current page.

--- a/tests/test_markdown_browser_paths.py
+++ b/tests/test_markdown_browser_paths.py
@@ -1,0 +1,106 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_browser(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pathvalidate", types.ModuleType("pathvalidate"))
+    for name in ["autoagent", "autoagent.environment", "autoagent.environment.markdown_browser"]:
+        package = types.ModuleType(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+
+    abstract = types.ModuleType("autoagent.environment.markdown_browser.abstract_markdown_browser")
+    abstract.AbstractMarkdownBrowser = object
+    monkeypatch.setitem(sys.modules, abstract.__name__, abstract)
+
+    search = types.ModuleType("autoagent.environment.markdown_browser.markdown_search")
+    search.AbstractMarkdownSearch = object
+
+    class BingMarkdownSearch:
+        def search(self, query):
+            return ""
+
+    search.BingMarkdownSearch = BingMarkdownSearch
+    monkeypatch.setitem(sys.modules, search.__name__, search)
+
+    mdconvert = types.ModuleType("autoagent.environment.markdown_browser.mdconvert")
+
+    class FileConversionException(Exception):
+        pass
+
+    class UnsupportedFormatException(Exception):
+        pass
+
+    class MarkdownConverter:
+        def convert_local(self, path):
+            return types.SimpleNamespace(title=None, text_content=Path(path).read_text(errors="replace"))
+
+        def convert_response(self, response):
+            return types.SimpleNamespace(title=None, text_content="")
+
+    mdconvert.FileConversionException = FileConversionException
+    mdconvert.UnsupportedFormatException = UnsupportedFormatException
+    mdconvert.MarkdownConverter = MarkdownConverter
+    monkeypatch.setitem(sys.modules, mdconvert.__name__, mdconvert)
+
+    browser_path = (
+        Path(__file__).resolve().parents[1]
+        / "autoagent"
+        / "environment"
+        / "markdown_browser"
+        / "requests_markdown_browser.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "autoagent.environment.markdown_browser.requests_markdown_browser",
+        browser_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module.RequestsMarkdownBrowser
+
+
+def test_docker_path_conversion_rejects_workspace_escape(monkeypatch, tmp_path):
+    RequestsMarkdownBrowser = load_browser(monkeypatch)
+    (tmp_path / "workplace").mkdir()
+    (tmp_path / "secret.txt").write_text("secret")
+    browser = RequestsMarkdownBrowser(local_root=str(tmp_path), workplace_name="workplace", start_page="about:blank")
+
+    try:
+        browser._convert_docker_to_local("/workplace/../secret.txt")
+    except ValueError as exc:
+        assert "escapes the workspace" in str(exc)
+    else:
+        raise AssertionError("workspace escape was accepted")
+
+
+def test_docker_path_conversion_allows_workspace_file(monkeypatch, tmp_path):
+    RequestsMarkdownBrowser = load_browser(monkeypatch)
+    workplace = tmp_path / "workplace"
+    workplace.mkdir()
+    safe_file = workplace / "note.txt"
+    safe_file.write_text("ok")
+    browser = RequestsMarkdownBrowser(local_root=str(tmp_path), workplace_name="workplace", start_page="about:blank")
+
+    converted = browser._convert_docker_to_local("/workplace/note.txt")
+
+    assert Path(converted) == safe_file.resolve()
+    assert browser.open_local_file(converted).strip() == "ok"
+
+
+def test_local_path_conversion_rejects_sibling_prefix(monkeypatch, tmp_path):
+    RequestsMarkdownBrowser = load_browser(monkeypatch)
+    (tmp_path / "workplace").mkdir()
+    sibling = tmp_path / "workplace-other" / "secret.txt"
+    sibling.parent.mkdir()
+    sibling.write_text("secret")
+    browser = RequestsMarkdownBrowser(local_root=str(tmp_path), workplace_name="workplace", start_page="about:blank")
+
+    try:
+        browser._convert_local_to_docker(str(sibling))
+    except ValueError as exc:
+        assert "escapes the workspace" in str(exc)
+    else:
+        raise AssertionError("sibling prefix path was accepted")


### PR DESCRIPTION
## Summary

This PR hardens File Surfer / Markdown Browser path conversion so Docker-workspace paths cannot escape the configured local workspace with traversal segments or sibling-prefix paths.

The patch replaces substring-based path checks with canonical path containment checks. Docker paths are now converted through a relative path under the configured Docker workspace, then resolved and verified under the configured local workspace before they can be opened.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| File Surfer workspace path traversal | A prompt, document, or tool caller could request a path such as `/workplace/../secret.txt` and read files outside the declared workspace | High |

## Before this PR

- `_convert_docker_to_local()` only checked whether the Docker workspace string appeared anywhere in the path.
- `_convert_local_to_docker()` only checked whether the local workspace string appeared anywhere in the path.
- Paths were converted with plain string replacement.
- `open_local_file()` later normalized the path, allowing `..` traversal to escape the workspace.
- Sibling paths with matching prefixes could also pass substring checks.

## After this PR

- Docker paths must be relative to the configured Docker workspace root.
- Converted local paths are canonicalized with `realpath`/`abspath`.
- Converted paths must remain under the configured local workspace using `commonpath` containment.
- Local-to-Docker conversion applies the same canonical containment check.
- Regression tests cover traversal rejection, safe workspace file access, and sibling-prefix rejection.

## Why this matters

File Surfer is presented as a scoped file browser for the agent workspace. If the path guard can be bypassed, untrusted prompt or document content can cause the agent to read host files outside that workspace and return their contents into the model context or transcript.

That can expose `.env` files, cloud credentials, SSH configuration, local source code, or other sensitive files reachable to the AutoAgent process.

## Attack flow

```text
Attacker influences File Surfer path argument
    -> path contains the workspace prefix plus traversal, e.g. /workplace/../secret.txt
        -> substring check accepts the path
            -> local path is normalized outside the workspace
                -> browser opens and returns the outside file content
```

## Affected code

| Area | Files |
|------|-------|
| Workspace path conversion | `autoagent/environment/markdown_browser/requests_markdown_browser.py` |
| Regression coverage | `tests/test_markdown_browser_paths.py` |

## Root cause

- Workspace checks used substring membership rather than canonical containment.
- String replacement did not remove or reject `..` path components.
- The actual file open path was normalized only after conversion, so traversal became effective after the weak check had already passed.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| File Surfer workspace path traversal | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N` |

Rationale:

- The attacker needs a path injection route through a prompt, document, or tool/API caller that can influence File Surfer.
- Exploitation is low complexity once the path reaches the tool.
- Successful exploitation can disclose sensitive local files and may influence downstream agent behavior through returned content.

## Safe reproduction steps

On vulnerable code:

1. Configure a Markdown Browser with local root `<tmp>` and workplace `<tmp>/workplace`.
2. Create `<tmp>/secret.txt` outside the workspace.
3. Convert and open:

   ```text
   /workplace/../secret.txt
   ```

4. Observe that the outside file content is returned.

With this PR:

1. The same conversion raises a workspace escape error.
2. A normal workspace file such as `/workplace/note.txt` still opens successfully.

## Expected vulnerable behavior

A path that contains `/workplace` but resolves outside the workspace is accepted and opened.

## Changes in this PR

- Adds a canonical `_contained_path()` helper.
- Rewrites Docker-to-local path conversion to use `PurePosixPath.relative_to()` plus local containment validation.
- Rewrites local-to-Docker conversion to validate canonical local containment before producing a Docker path.
- Adds regression tests for traversal rejection, safe path conversion, and sibling-prefix rejection.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Path containment | `autoagent/environment/markdown_browser/requests_markdown_browser.py` | Replaced substring path checks with canonical workspace containment. |
| Tests | `tests/test_markdown_browser_paths.py` | Added coverage for traversal, safe access, and sibling-prefix cases. |

## Maintainer impact

- Legitimate files under the configured workspace continue to work.
- Paths that previously relied on `..` to leave the workspace are now rejected.
- The public File Surfer API shape is unchanged.

## Fix rationale

For filesystem boundaries, prefix or substring checks are not sufficient. The robust boundary is to resolve both the workspace root and candidate path to canonical paths and require the candidate to remain under the root with `commonpath`.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3 -m pytest tests/test_markdown_browser_paths.py -q`
- [x] `python3 -m py_compile autoagent/environment/markdown_browser/requests_markdown_browser.py tests/test_markdown_browser_paths.py`
- [x] `git diff --check`

## Disclosure notes

- This PR is bounded to File Surfer / Markdown Browser workspace path containment.
- It does not address the separate FastAPI tool API or TCP command server exposure, which are handled separately.
- No unrelated files were changed.
