### PR TITLE
fix: guard LLM response access before dereferencing choices/content

### DIFF
--- a/autoagent/environment/markdown_browser/mdconvert.py
+++ b/autoagent/environment/markdown_browser/mdconvert.py
@@ -789,6 +789,8 @@ class ImageConverter(MediaConverter):
         ]
 
         response = client.chat.completions.create(model=model, messages=messages)
+        if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
 

--- a/autoagent/environment/mdconvert.py
+++ b/autoagent/environment/mdconvert.py
@@ -796,6 +796,8 @@ def _get_page_markdown():
             ]
 
             response = client.chat.completions.create(model=model, messages=messages)
+            if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
+                raise ValueError("LLM returned empty or filtered response")
             return response.choices[0].message.content
 
 

--- a/docs/translation_updater.py
+++ b/docs/translation_updater.py
@@ -61,6 +61,8 @@ def translate_content(content, target_lang):
         ],
     )
 
+    if not message.content or message.content[0].text is None:
+        raise ValueError("LLM returned empty or filtered response")
     return message.content[0].text
 
 


### PR DESCRIPTION
## What

Guard LLM response access in three files before dereferencing `.choices[0]` or `.content[0]`.

## Why

`response.choices[0].message.content` is typed `Optional[str]` in the OpenAI SDK — it returns `None` (not raises) when `finish_reason` is `"tool_calls"` or the provider applies content filtering. Similarly, the Anthropic SDK can return an empty `content` list on filtered responses, making `message.content[0].text` unsafe without a length check.

**`autoagent/environment/mdconvert.py`** and **`autoagent/environment/markdown_browser/mdconvert.py`** (OpenAI):
```python
# before
return response.choices[0].message.content

# after
if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

**`docs/translation_updater.py`** (Anthropic):
```python
# before
return message.content[0].text

# after
if not message.content or message.content[0].text is None:
    raise ValueError("LLM returned empty or filtered response")
return message.content[0].text
```

## Test plan

- [ ] Verify `translate_content()` raises `ValueError` when given a mock `message.content = []`
- [ ] Verify the mdconvert LLM path raises `ValueError` when given a mock `response.choices = []`

🤖 Generated with [Claude Code](https://claude.ai/code)